### PR TITLE
Don't modify options in Count methods

### DIFF
--- a/draft.go
+++ b/draft.go
@@ -93,11 +93,11 @@ func (c *Client) DraftsCount(ctx context.Context, opts *DraftsOptions) (int, err
 	if opts == nil {
 		opts = &DraftsOptions{}
 	}
-	opts.View = ViewCount
 	vs, err := query.Values(opts)
 	if err != nil {
 		return 0, err
 	}
+	vs.Set("view", ViewCount)
 	appendQueryValues(req, vs)
 
 	var resp countResponse

--- a/message.go
+++ b/message.go
@@ -113,11 +113,11 @@ func (c *Client) MessagesCount(ctx context.Context, opts *MessagesOptions) (int,
 	if opts == nil {
 		opts = &MessagesOptions{}
 	}
-	opts.View = ViewCount
 	vs, err := query.Values(opts)
 	if err != nil {
 		return 0, err
 	}
+	vs.Set("view", ViewCount)
 	appendQueryValues(req, vs)
 
 	var resp countResponse

--- a/thread.go
+++ b/thread.go
@@ -114,11 +114,11 @@ func (c *Client) ThreadsCount(ctx context.Context, opts *ThreadsOptions) (int, e
 	if opts == nil {
 		opts = &ThreadsOptions{}
 	}
-	opts.View = ViewCount
 	vs, err := query.Values(opts)
 	if err != nil {
 		return 0, err
 	}
+	vs.Set("view", ViewCount)
 	appendQueryValues(req, vs)
 
 	var resp countResponse


### PR DESCRIPTION
Avoids unexpected results when reusing options between the list and count
requests.