### PR TITLE
Implment delete file

### DIFF
--- a/file.go
+++ b/file.go
@@ -123,3 +123,14 @@ func (c *Client) DownloadFile(ctx context.Context, id string) (io.ReadCloser, er
 	}
 	return resp.Body, nil
 }
+
+// DeleteFile removes an existing file identified by the specified file ID.
+// See: https://docs.nylas.com/reference#files-delete
+func (c *Client) DeleteFile(ctx context.Context, id string) error {
+	endpoint := fmt.Sprintf("/files/%s", id)
+	req, err := c.newUserRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -132,6 +132,23 @@ func TestDownloadFile(t *testing.T) {
 	}
 }
 
+func TestDeleteFile(t *testing.T) {
+	accessToken := "accessToken"
+	id := "br57kcekhf1hsjq04y8aonkit"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertBasicAuth(t, r, accessToken, "")
+		assertMethodPath(t, r, http.MethodDelete, "/files/"+id)
+
+	}))
+	defer ts.Close()
+
+	client := NewClient("", "", withTestServer(ts), WithAccessToken(accessToken))
+	err := client.DeleteFile(context.Background(), id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 var getFileJSON = []byte(`{
     "account_id": "43jf3n4e***",
     "content_type": "image/png",


### PR DESCRIPTION
The following is the implementation of `DELETE /files/{id}` see: https://docs.nylas.com/reference#files-delete 