### PR TITLE
Extract and expose webhook handler logic as http.Handler

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -12,6 +12,59 @@ import (
 	"net/http"
 )
 
+// WebhookHandler returns a new http.Handler for handling Nylas webhooks.
+//
+// The X-Nylas-Signature will be verified and any non-nil error returned from fn
+// will result in a 500 response with the error message.
+//
+// When mounting this route it should be called for both GET and POST requests
+// to handle the initial webhook setup.
+//
+// See: https://docs.nylas.com/reference#receiving-notifications
+func WebhookHandler(clientSecret string, fn func(WebhookDelta) error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			challenge := r.URL.Query().Get("challenge")
+			if r.Method == http.MethodGet && challenge != "" {
+				w.Header().Add("Content-Type", "text/plain")
+				_, _ = io.WriteString(w, challenge)
+				return
+			}
+
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		signature := r.Header.Get("X-Nylas-Signature")
+		if err := checkSignature(clientSecret, signature, data); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp := struct {
+			Deltas []WebhookDelta `json:"deltas"`
+		}{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			msg := fmt.Sprintf("unmarshal delta: %v", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		for _, delta := range resp.Deltas {
+			if err := fn(delta); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	})
+}
+
 // WebhookListener receives requests from a Nylas webhook.
 // See: https://docs.nylas.com/reference#webhooks
 type WebhookListener struct {
@@ -33,46 +86,7 @@ func NewWebhookListener(clientSecret string) *WebhookListener {
 // See: https://docs.nylas.com/reference#receiving-notifications
 func (l *WebhookListener) Listen(addr string, fn func(WebhookDelta) error) error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			challenge := r.URL.Query().Get("challenge")
-			if r.Method == http.MethodGet && challenge != "" {
-				_, _ = io.WriteString(w, challenge)
-				return
-			}
-
-			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		data, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		signature := r.Header.Get("X-Nylas-Signature")
-		if err := checkSignature(l.clientSecret, signature, data); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		resp := struct {
-			Deltas []WebhookDelta `json:"deltas"`
-		}{}
-		if err := json.Unmarshal(data, &resp); err != nil {
-			msg := fmt.Sprintf("unmarshal delta: %v", err)
-			http.Error(w, msg, http.StatusInternalServerError)
-			return
-		}
-
-		for _, delta := range resp.Deltas {
-			if err := fn(delta); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		}
-	})
+	mux.Handle("/", WebhookHandler(l.clientSecret, fn))
 	return http.ListenAndServe(addr, mux)
 }
 


### PR DESCRIPTION
- Extracted logic for handling webhook to WebhookHandler to allow easier reuse
- Set Content-Type on challenge request to avoid rendering HTML