### PR TITLE
Add thread id filter to the draft endpoint

### DIFF
--- a/draft.go
+++ b/draft.go
@@ -56,6 +56,9 @@ type DraftsOptions struct {
 	Limit  int    `url:"limit,omitempty"`
 	Offset int    `url:"offset,omitempty"`
 
+	// Return messages belonging to a specific thread
+	ThreadID string `url:"thread_id,omitempty"`
+
 	// Return drafts that have been sent or received from the list of
 	// email addresses. A maximum of 25 emails may be specified
 	AnyEmail []string `url:"any_email,comma,omitempty"`


### PR DESCRIPTION
This PR adds an option to filter by thread id when fetching drafts.

It looks like the documentation is not updated: https://docs.nylas.com/reference#get-drafts

I did a test locally and the "thread_id" filter is available for the `GET /drafts` endpoint.